### PR TITLE
Implement ArticlePage and parsing Markdown articles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,10 @@
     "": {
       "name": "polarisblog",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.0",
+        "marked": "^15.0.7",
+        "postcss": "^8.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.4.1",
@@ -223,6 +226,8 @@
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHXRXRxB7HBmkUE8U13nmkGGYfR1I2vsuhiYjeDDUFIYpk1BL6caU8hvzkSlL/X5CAQNdIUUJRGom5I0ZyfJOA=="],
 
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.16", "", { "dependencies": { "lodash.castarray": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.merge": "^4.6.2", "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA=="],
+
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.0", "", { "dependencies": { "@tailwindcss/node": "4.1.0", "@tailwindcss/oxide": "4.1.0", "tailwindcss": "4.1.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6" } }, "sha512-IszG0h/o8jOGheY0f7v41a9qyDymZ5eU8qm4koTypMKagBhaQA06Keip13wch6sz7rG3cvIG7A3/ytdfRh2BUw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -304,6 +309,8 @@
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
@@ -453,11 +460,17 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "lodash.castarray": ["lodash.castarray@4.4.0", "", {}, "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
+
+    "marked": ["marked@15.0.7", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -496,6 +509,8 @@
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -564,6 +579,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vite": ["vite@6.2.4", "", { "dependencies": { "esbuild": "^0.25.0", "postcss": "^8.5.3", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.0",
+    "marked": "^15.0.7",
+    "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.4.1",

--- a/public/articles/first-article.md
+++ b/public/articles/first-article.md
@@ -1,0 +1,87 @@
+# Polaris Blog
+
+一个使用 React、TypeScript 和 Tailwind CSS 构建的简单博客应用。
+
+## 功能特性
+
+- 简洁、响应式设计，基于 Tailwind CSS
+- GitHub Pages 部署集成
+
+## 技术栈
+
+- **前端框架:** React 19 与 TypeScript
+- **路由管理:** React Router v7
+- **样式设计:** Tailwind CSS v4
+- **构建工具:** Vite
+- **包管理器:** Bun
+- **代码检查:** Biome
+- **部署方式:** GitHub Actions 自动化部署到 GitHub Pages
+
+## 开始使用
+
+### 前提条件
+
+- Bun
+
+### 安装步骤
+
+1. 克隆仓库:
+   ```bash
+   git clone https://github.com/nkanf-dev/PolarisBlog.git
+   cd PolarisBlog
+   ```
+
+2. 安装依赖:
+   ```bash
+   bun install
+   ```
+
+3. 启动开发服务器:
+   ```bash
+   bun run dev
+   ```
+
+4. 打开浏览器并访问 `http://localhost:5173/`
+
+## 项目结构
+
+- `/src` - 主要源代码
+  - `/components` - 可复用的 UI 组件
+  - `/pages` - 不同路由的页面组件
+  - `App.tsx` - 主应用组件
+  - `main.tsx` - 应用入口点
+- `/public` - 静态资源
+
+## 部署
+
+本项目已配置使用 GitHub Actions 自动部署到 GitHub Pages。
+
+### 手动部署
+
+要手动部署:
+
+```bash
+bun run deploy
+```
+
+### 自动部署
+
+推送到 `main` 分支将触发 GitHub Actions 工作流，自动构建并部署站点到 GitHub Pages。
+
+## 贡献
+
+1. Fork 仓库
+2. 创建功能分支 (`git checkout -b feature/amazing-feature`)
+3. 提交更改 (`git commit -m '添加某个令人惊叹的功能'`)
+4. 推送到分支 (`git push origin feature/amazing-feature`)
+5. 开启 Pull Request
+
+## 许可证
+
+本项目采用 MIT 许可证 - 详情请参阅 LICENSE 文件。
+
+## 致谢
+
+- React 团队提供的出色框架
+- Tailwind CSS 提供的实用优先的 CSS 框架
+- Vite 提供的高速构建工具

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Archives from "./pages/Archives";
 import About from "./pages/About";
+import ArticlePage from "./pages/ArticlePage"; // P9e3a
 
 function App() {
 	return (
@@ -15,6 +16,7 @@ function App() {
 					<Route path="/" element={<Home />} />
 					<Route path="/archives" element={<Archives />} />
 					<Route path="/about" element={<About />} />
+					<Route path="/article/:id" element={<ArticlePage />} /> // Pd6ea
 				</Routes>
 			</div>
 		</>

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,14 +1,26 @@
+import { useNavigate } from "react-router-dom";
+
 interface ArticleCardProps {
 	content: string;
 	date: Date | string;
+	id: string;
 }
 
-export function ArticleCard({ content, date }: ArticleCardProps) {
+export function ArticleCard({ content, date, id }: ArticleCardProps) {
+	const navigate = useNavigate();
 	const dateString =
 		typeof date === "string" ? date : date.toLocaleDateString();
+
+	const handleClick = () => {
+		navigate(`/article/${id}`);
+	};
+
 	return (
 		<>
-			<div className="flex flex-col content-center bg-white p-5 rounded-lg shadow-lg mt-2.5">
+			<div
+				className="flex flex-col content-center bg-white p-5 rounded-lg shadow-lg mt-2.5 cursor-pointer"
+				onClick={handleClick}
+			>
 				<p>{content}</p>
 				<div className="flex flex-row mt-2.5">
 					<span className="text-gray-500 text-sm">{dateString}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { marked } from 'marked';
+
+const ArticlePage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [content, setContent] = useState<string>('');
+  const [date, setDate] = useState<string>('');
+
+  useEffect(() => {
+    const fetchArticle = async () => {
+      try {
+        const response = await fetch(`/articles/${id}.md`);
+        const text = await response.text();
+        const html = marked(text);
+        setContent(html);
+        setDate(new Date().toLocaleDateString());
+      } catch (error) {
+        console.error('Error fetching article:', error);
+      }
+    };
+
+    fetchArticle();
+  }, [id]);
+
+  return (
+    <div className="mt-5 bg-white p-5 rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-4">Article</h2>
+      <div className="mb-4" dangerouslySetInnerHTML={{ __html: content }} />
+      <p className="text-gray-500 text-sm">{date}</p>
+    </div>
+  );
+};
+
+export default ArticlePage;

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -10,11 +10,17 @@ const ArticlePage: React.FC = () => {
   useEffect(() => {
     const fetchArticle = async () => {
       try {
-        const response = await fetch(`/articles/${id}.md`);
+        const response = await fetch(`/articles/${id}.md`)
         const text = await response.text();
-        const html = marked(text);
-        setContent(html);
-        setDate(new Date().toLocaleDateString());
+        if (!text.startsWith("<!doctype html>")) {
+          const html = await marked(text);
+          setContent(html);
+          setDate(new Date().toLocaleDateString());
+        }
+
+        else {
+          setContent("<h1>404 Not Found</h1>")
+        }
       } catch (error) {
         console.error('Error fetching article:', error);
       }
@@ -25,8 +31,8 @@ const ArticlePage: React.FC = () => {
 
   return (
     <div className="mt-5 bg-white p-5 rounded-lg shadow-md">
-      <h2 className="text-2xl font-bold mb-4">Article</h2>
-      <div className="mb-4" dangerouslySetInnerHTML={{ __html: content }} />
+      <h2 className="text-2xl font-bold mb-4">{id}</h2>
+      <div className="prose mb-4" dangerouslySetInnerHTML={{ __html: content }} />
       <p className="text-gray-500 text-sm">{date}</p>
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,8 @@ import { ArticleCard } from "../components/ArticleCard";
 export default function Home() {
   return (
     <div className="mt-5">
-      <ArticleCard content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date={new Date(Date.now())} />
-      <ArticleCard content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date="2025/4/3" />
+      <ArticleCard id="1" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date={new Date(Date.now())} />
+      <ArticleCard id="2" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date="2025/4/3" />
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,8 @@ import { ArticleCard } from "../components/ArticleCard";
 export default function Home() {
   return (
     <div className="mt-5">
-      <ArticleCard id="1" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date={new Date(Date.now())} />
-      <ArticleCard id="2" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." date="2025/4/3" />
+      <ArticleCard id="first-article" content="第一篇文章, 其实是Readme" date={new Date(Date.now())} />
+      <ArticleCard id="2" content="其实没有这个文章" date="2025/4/1" />
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,3 @@
+export const plugins = [
+  require('@tailwindcss/typography'),
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,0 @@
-export default ({
-  content: [
-    "./src/**/*.{js,jsx,ts,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-});


### PR DESCRIPTION
Implement the functionality to navigate to the corresponding `ArticlePage` when clicking on an `ArticleCard`.

* **Add `ArticlePage` component**:
  - Create `src/pages/ArticlePage.tsx` to display the content of an article.
  - Add logic to dynamically read `public/articles/*.md` based on the id and parse it as HTML.

* **Update routing in `src/App.tsx`**:
  - Import `ArticlePage` component.
  - Add a new route for `ArticlePage` with the path `/article/:id`.

* **Update `ArticleCard` component**:
  - Import `useNavigate` hook from `react-router-dom`.
  - Add an `onClick` event handler to navigate to the corresponding `ArticlePage`.

* **Update `Home` component**:
  - Pass an `id` prop to each `ArticleCard` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkanf-dev/PolarisBlog/pull/3?shareId=f268f3e1-483a-4e1b-8060-e795f8faaafb).